### PR TITLE
Added missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "abstract-connection",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "A test suite and interface you can use to implement a connection interface.",
   "repository": {
     "type": "git",
@@ -14,5 +14,8 @@
   "bugs": {
     "url": "https://github.com/diasdavid/abstract-connection/issues"
   },
-  "homepage": "https://github.com/diasdavid/abstract-connection"
+  "homepage": "https://github.com/diasdavid/abstract-connection",
+  "dependencies": {
+    "timed-tape": "^0.1.0"
+  }
 }


### PR DESCRIPTION
#### :tophat: What? Why?

While this is currently a placeholder and tests need to be implemented it would be good if the different transports could already implement the tests. Right now it breaks because `timed-tape` is a missing dependency.
