### PR TITLE
feat: add support for timeline proxying

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "dirty-chai": "^2.0.1",
     "err-code": "^2.0.0",
     "multiaddr": "^7.1.0",
-    "peer-id": "~0.13.2"
+    "peer-id": "~0.13.2",
+    "sinon": "^7.5.0"
   },
   "devDependencies": {
     "aegir": "^20.2.0",

--- a/src/connection.js
+++ b/src/connection.js
@@ -75,10 +75,6 @@ class Connection {
      */
     this._stat = {
       ...stat,
-      timeline: {
-        ...stat.timeline,
-        close: undefined
-      },
       status: 'open'
     }
 

--- a/test/compliance.spec.js
+++ b/test/compliance.spec.js
@@ -10,7 +10,12 @@ const pair = require('it-pair')
 
 describe('compliance tests', () => {
   tests({
-    async setup () {
+    /**
+     * Test setup. `properties` allows the compliance test to override
+     * certain values for testing.
+     * @param {*} properties
+     */
+    async setup (properties) {
       const localAddr = multiaddr('/ip4/127.0.0.1/tcp/8080')
       const remoteAddr = multiaddr('/ip4/127.0.0.1/tcp/8081')
       const [localPeer, remotePeer] = await Promise.all([
@@ -49,7 +54,8 @@ describe('compliance tests', () => {
           }
         },
         close: () => {},
-        getStreams: () => openStreams
+        getStreams: () => openStreams,
+        ...properties
       })
     },
     async teardown () {


### PR DESCRIPTION
In Libp2p we need to know when a connection has closed, as it allows us to do a variety of clean up tasks, notifications, etc. Rather than passing additional handlers to be able to know when the connection has closed, this simply removes the `stat.timeline` destructuring in the constructor to allow Proxies to work properly. As shown in the tests, this enables us to create custom handlers when certain properties change, namely `timeline.close`. When the value is set by the `MultiaddrConnection`, we can perform any actions the rest of the system needs.